### PR TITLE
adds fullfiller oas

### DIFF
--- a/bfp_v1.json
+++ b/bfp_v1.json
@@ -1,0 +1,588 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Bando Fulfillment Protocol REST API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Bando Support",
+      "email": "devs@bando.cool",
+      "url": "https://developers.bando.cool"
+    },
+    "description": ""
+  },
+  "servers": [
+    {
+      "url": "https://api.bando.cool/v1"
+    }
+  ],
+  "tags": [
+  ],
+  "paths": {
+    "/products": {
+      "get": {
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "tags": [
+          "Products"
+        ],
+        "summary": "Get list of existing products",
+        "parameters": [
+          {
+            "name": "page_number",
+            "in": "query",
+            "description": "Page number (starts from 1)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "Page size (number of items per page)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "name": "brand",
+            "in": "query",
+            "description": "Brand to filter"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "name": "country",
+            "in": "query",
+            "description": "2 letter ISO code for the destination country to filter"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "name": "type",
+            "in": "query",
+            "description": "Product type to filter"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "name": "subType",
+            "in": "query",
+            "description": "Offer subtype to filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dto.ProductsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dto.ResponseError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - API Token Missing or Unrecognized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dto.ResponseError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - IP Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dto.ResponseError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dto.ResponseError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/references": {
+      "post": {
+        "tags": [
+          "References"
+        ],
+        "summary": "Create a new validated reference",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/dto.CreateValidatedReference"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Reference created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dto.ValidatedReference"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "References"
+        ],
+        "summary": "Retrieve validated references",
+        "parameters": [
+          {
+            "name": "validation_id",
+            "in": "query",
+            "description": "Validation ID to filter references",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get validated reference",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/dto.ValidatedReference"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/quotes": {
+      "post": {
+        "tags": [
+          "Quotes"
+        ],
+        "summary": "Get a conversion quote for fiat to digital assets",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/dto.CreateQuote"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Quote retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dto.Quote"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "dto.ProductsResponse": {
+        "type": "object",
+        "description": "Catalog response for product searches",
+        "properties": {
+          "totalItems": {
+            "type": "integer",
+            "description": "Total number of products"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number of pages"
+          },
+          "currentPage": {
+            "type": "integer",
+            "description": "Current page"
+          },
+          "products": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/dto.Esim"
+                },
+                {
+                  "$ref": "#/components/schemas/dto.Topup"
+                },
+                {
+                  "$ref": "#/components/schemas/dto.GiftCard"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "dto.Product": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "productType"
+        },
+        "properties": {
+          "brand": {
+            "description": "Brand of product",
+            "type": "string"
+          },
+          "country": {
+            "description": "Destination country for products",
+            "type": "string"
+          },
+          "notes": {
+            "description": "Notes included about the product",
+            "type": "string"
+          },
+          "sku": {
+            "description": "Catalog SKU of the product",
+            "type": "string"
+          },
+          "price": {
+            "description": "Price to customer",
+            "$ref": "#/components/schemas/dto.Price"
+          },
+          "productType": {
+            "description": "Product type",
+            "type": "string"
+          },
+          "shortNotes": {
+            "description": "Short notes for product",
+            "type": "string"
+          },
+          "subTypes": {
+            "description": "Product subtypes",
+            "type": "array",
+            "items": {
+              "description": "Subtype entry",
+              "type": "string"
+            }
+          }
+        }
+      },
+      "dto.MobileData": {
+        "type": "object",
+        "description": "Mobile Data type Product",
+        "properties": {
+          "dataGB": {
+            "description": "Amount of data included (0 when data is unlimited)",
+            "type": "integer"
+          },
+          "dataSpeeds": {
+            "description": "Available data speeds for destination",
+            "type": "array",
+            "items": {
+              "description": "Data speed entries",
+              "type": "string"
+            }
+          },
+          "dataUnlimited": {
+            "description": "Flag for unlimited data",
+            "type": "boolean"
+          },
+          "durationDays": {
+            "description": "Duration of the offer in days",
+            "type": "integer"
+          },
+          "smsNumber": {
+            "description": "Included SMS messages (0 when unlimited or not included, check smsUnlimited flag)",
+            "type": "integer"
+          },
+          "smsUnlimited": {
+            "description": "Flag whether SMS messaging is unlimited for offer",
+            "type": "boolean"
+          },
+          "voiceMinutes": {
+            "description": "Voice minutes included (0 when unlimited or not included, check voiceUnlimited Flag)",
+            "type": "integer"
+          },
+          "voiceUnlimited": {
+            "description": "Flag whether voice minutes are unlimited for the offer",
+            "type": "boolean"
+          }
+        }
+      },
+      "dto.SendPriceData": {
+        "type": "object",
+        "description": "",
+        "properties": {
+          "send_currency": {
+            "description": "Currency for the value",
+            "type": "string"
+          },
+          "send_price": {
+            "description": "Price in string to prevent lose precision",
+            "type": "string"
+          }
+        }
+      },
+      "dto.Esim": {
+        "type": "object",
+        "description": "esim Product",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/dto.Product"
+          },
+          {
+            "$ref": "#/components/schemas/dto.MobileData"
+          },
+          {
+            "properties": {
+              "roamingCountryIso2": {
+                "description": "2 letter ISO country code",
+                "type": "string"
+              },
+              "roamingDataSpeeds": {
+                "description": "Available data speeds for destination",
+                "type": "array",
+                "items": {
+                  "description": "Data speed entries",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dto.Topup": {
+        "type": "object",
+        "description": "esim Product",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/dto.Product"
+          },
+          {
+            "$ref": "#/components/schemas/dto.MobileData"
+          },
+          {
+            "$ref": "#/components/schemas/dto.SendPriceData"
+          }
+        ]
+      },
+      "dto.GiftCard": {
+        "type": "object",
+        "description": "Gift Card Product",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/dto.Product"
+          },
+          {
+            "$ref": "#/components/schemas/dto.SendPriceData"
+          }
+        ]
+      },
+      "dto.Price": {
+        "type": "object",
+        "description": "Pricing for product",
+        "properties": {
+          "fiat_currency": {
+            "description": "Price in FIAT currency",
+            "type": "string"
+          },
+          "fiat_value": {
+            "description": "Price for the product in FIAT, in a string value to prevent lost precision",
+            "type": "string"
+          },
+          "stable_coin_currency": {
+            "description": "Price in a cripto stable coin like USDC or USDT",
+            "type": "string"
+          },
+          "stable_coin_value": {
+            "description": "Price for the product in stable coin, in a string value to prevent lost precision",
+            "type": "string"
+          }
+        }
+      },
+      "dto.ResponseError": {
+        "description": "API error responses",
+        "type": "object",
+        "properties": {
+          "errorCode": {
+            "description": "Error code for the error",
+            "type": "string"
+          },
+          "fields": {
+            "description": "Supplemental information about fields in error (when available)",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "message": {
+            "description": "Detail message for the error",
+            "type": "string"
+          }
+        }
+      },
+      "regions": {
+        "description": "List of available regions",
+        "type": "string",
+        "enum": [
+          "Global",
+          "Africa",
+          "Asia",
+          "Caribbean",
+          "Central America",
+          "Eastern Europe",
+          "Western Europe",
+          "North America",
+          "Oceania",
+          "South America",
+          "South Asia",
+          "Southeast Asia",
+          "Middle East and North Africa"
+        ]
+      },
+      "dto.CreateValidatedReference": {
+        "type": "object",
+        "required": ["sku"],
+        "properties": {
+          "reference": {
+            "type": "string",
+            "description": "User-provided reference (e.g., phone number, email)"
+          },
+          "reference_required_fields": {
+            "type": "object",
+            "description": "Required fields for validating the reference"
+          },
+          "sku": {
+            "type": "string",
+            "description": "SKU related to the reference"
+          }
+        }
+      },
+      "dto.ValidatedReference": {
+        "type": "object",
+        "properties": {
+          "reference": {
+            "type": "string",
+            "description": "User-provided reference"
+          },
+          "reference_required_fields": {
+            "type": "object",
+            "description": "Fields required to validate the reference"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the reference"
+          },
+          "reference_type": {
+            "type": "string",
+            "description": "Type of reference (e.g., phone number, email)"
+          }
+        }
+      },
+      "dto.CreateQuote": {
+        "type": "object",
+        "required": ["fiat_currency", "digital_asset", "sku"],
+        "properties": {
+          "fiat_currency": {
+            "type": "string",
+            "description": "Fiat currency for request."
+          },
+          "digital_asset": {
+            "type": "string",
+            "description": "Requested stablecoin used for pricing (e.g., USDC)"
+          },
+          "sku": {
+            "type": "string",
+            "description": "Product identifier"
+          }
+        }
+      },
+      "dto.Quote": {
+
+        "type": "object",
+        "properties": {
+        "fiat_currency": {
+          "type": "string",
+          "description": "Local fiat currency for product pricing."
+        },
+        "fiat_amount": {
+          "type": "string",
+          "description": "Price in fiat currency"
+        },
+        "digital_asset": {
+          "type": "string",
+          "description": "Requested stablecoin used for pricing (e.g., USDC)"
+        },
+        "digital_asset_amount": {
+          "type": "string",
+          "description": "Product price in digital asset"
+        },
+          "sku": {
+            "type": "string",
+            "description": "Product sku"
+          }
+      }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "TOKEN",
+        "description": "Authentication: Bearer YOUR_API_KEY"
+      }
+    }
+  }

--- a/fulfiller-api/api-reference/catalog.md
+++ b/fulfiller-api/api-reference/catalog.md
@@ -2,9 +2,6 @@
 
 ## 1. Overview
 
-This document outlines the design and implementation of the Fiat-to-Digital Asset Conversion API.  
-The API facilitates converting fiat currencies to digital assets and returns a quoted amount based on   
-current exchange rates. It supports configurable spreads and multiple external providers for FX and crypto pricing.
 
 ## 2. Objectives
 
@@ -46,35 +43,6 @@ sequenceDiagram
 
 ### Endpoint
 
-- **URL**: `/api/v1/quotes/`
-- **Method**: `POST`
-
-### Request Body
-
-```json
-{
-  "fiat_currency": "string",
-  "digital_asset": "string",
-  "sku": "string"
-}
-```
-
-* **fiat_currency**: ISO 4217 code for the fiat currency (e.g., "USD").
-* **digital_asset**: Digital asset for conversion (e.g., "USDC").
-* **sku**: Product identifier.
-
-Response Body
-```json
-{
-  "fiat_currency": "string",
-  "fiat_amount": "string",
-  "digital_asset": "string",
-  "digital_asset_amount": "string",
-  "sku": "string"
-}
-```
-* **fiat_currency**: The fiat currency used.
-* **fiat_amount**: The amount in fiat currency.
-* **digital_asset**: The digital asset converted to.
-* **digital_asset_amount**: The quoted amount in the digital asset.
-* **sku**: Product identifier.
+{% swagger src="./bfp_v1.json" path="/products" method="get" expanded="true" %} 
+[openapi.json](./openapi.json) 
+{% endswagger %}

--- a/fulfiller-api/api-reference/catalog.md
+++ b/fulfiller-api/api-reference/catalog.md
@@ -43,6 +43,6 @@ sequenceDiagram
 
 ### Endpoint
 
-{% swagger src="./bfp_v1.json" path="/products" method="get" expanded="true" %} 
-[openapi.json](./openapi.json) 
+{% swagger src="/bfp_v1.json" path="/products" method="get" expanded="true" %} 
+[bfp_v1.json](/bfp_v1.json) 
 {% endswagger %}

--- a/fulfiller-api/api-reference/catalog.md
+++ b/fulfiller-api/api-reference/catalog.md
@@ -5,38 +5,10 @@
 
 ## 2. Objectives
 
-- Allow users to convert fiat currencies into supported digital assets.
-- Provide real-time quotes based on exchange rates from selected providers.
-- Enable configurable spreads and flexible rate sources.
-- Integrate with external providers for fiat and cryptocurrency rates.
 
 ## 3. Architecture
 
-The API involves interaction with various components for currency conversion and quote calculation.
 
-```mermaid
-sequenceDiagram
-    participant Client
-    participant QuoteService
-    participant ProductRepository
-    participant QuoteFiatProvider
-    participant QuoteDigitalProvider
-
-    Client->>QuoteService: create_quote(fiat_currency, digital_asset, sku)
-    QuoteService->>ProductRepository: find_product_variation_by_sku(sku)
-    ProductRepository-->>QuoteService: Product
-
-    QuoteService->>QuoteDigitalProvider: get_ticker_data(digital_asset_symbol)
-    QuoteDigitalProvider-->>QuoteService: price_stable_coin_value
-
-    QuoteService->>QuoteFiatProvider: request_conversion(fiat_amount, fiat_currency, product_fiat_currency)
-    QuoteFiatProvider-->>QuoteService: converted_fiat_amount
-
-    QuoteService->>QuoteService: _calculate_digital_asset_amount(converted_fiat_amount, price_stable_coin_value, spread)
-    Note right of QuoteService: Applies the spread to adjust the price
-
-    QuoteService-->>Client: Quote (fiat_currency, fiat_amount, digital_asset, digital_asset_amount, sku)
-```
 
 
 ## API Specification

--- a/fulfiller-api/api-reference/catalog.md
+++ b/fulfiller-api/api-reference/catalog.md
@@ -1,0 +1,80 @@
+# Product Catalog endpoint API
+
+## 1. Overview
+
+This document outlines the design and implementation of the Fiat-to-Digital Asset Conversion API.  
+The API facilitates converting fiat currencies to digital assets and returns a quoted amount based on   
+current exchange rates. It supports configurable spreads and multiple external providers for FX and crypto pricing.
+
+## 2. Objectives
+
+- Allow users to convert fiat currencies into supported digital assets.
+- Provide real-time quotes based on exchange rates from selected providers.
+- Enable configurable spreads and flexible rate sources.
+- Integrate with external providers for fiat and cryptocurrency rates.
+
+## 3. Architecture
+
+The API involves interaction with various components for currency conversion and quote calculation.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant QuoteService
+    participant ProductRepository
+    participant QuoteFiatProvider
+    participant QuoteDigitalProvider
+
+    Client->>QuoteService: create_quote(fiat_currency, digital_asset, sku)
+    QuoteService->>ProductRepository: find_product_variation_by_sku(sku)
+    ProductRepository-->>QuoteService: Product
+
+    QuoteService->>QuoteDigitalProvider: get_ticker_data(digital_asset_symbol)
+    QuoteDigitalProvider-->>QuoteService: price_stable_coin_value
+
+    QuoteService->>QuoteFiatProvider: request_conversion(fiat_amount, fiat_currency, product_fiat_currency)
+    QuoteFiatProvider-->>QuoteService: converted_fiat_amount
+
+    QuoteService->>QuoteService: _calculate_digital_asset_amount(converted_fiat_amount, price_stable_coin_value, spread)
+    Note right of QuoteService: Applies the spread to adjust the price
+
+    QuoteService-->>Client: Quote (fiat_currency, fiat_amount, digital_asset, digital_asset_amount, sku)
+```
+
+
+## API Specification
+
+### Endpoint
+
+- **URL**: `/api/v1/quotes/`
+- **Method**: `POST`
+
+### Request Body
+
+```json
+{
+  "fiat_currency": "string",
+  "digital_asset": "string",
+  "sku": "string"
+}
+```
+
+* **fiat_currency**: ISO 4217 code for the fiat currency (e.g., "USD").
+* **digital_asset**: Digital asset for conversion (e.g., "USDC").
+* **sku**: Product identifier.
+
+Response Body
+```json
+{
+  "fiat_currency": "string",
+  "fiat_amount": "string",
+  "digital_asset": "string",
+  "digital_asset_amount": "string",
+  "sku": "string"
+}
+```
+* **fiat_currency**: The fiat currency used.
+* **fiat_amount**: The amount in fiat currency.
+* **digital_asset**: The digital asset converted to.
+* **digital_asset_amount**: The quoted amount in the digital asset.
+* **sku**: Product identifier.


### PR DESCRIPTION
# Pull Request Overview

Adds the Bando API OAS so it can be used in the documentation.

Now that we can reference our contract from the documents, there is no need to add the endpoint specification manually.
https://docs.bando.cool/~/revisions/YC8QlSga5zxTAzHpzep2/fulfiller-api/api-reference/catalog

## Key Changes

1. Upload the OAS from the `core-fulfiller` project
2. Uses the OAS from the API Reference page 

![image](https://github.com/user-attachments/assets/4e5b08e2-eb4a-48ac-9842-e47094c9c10b)


## Notes

To integrate the OAS is quite simple:

```
## API Specification

### Endpoint

{% swagger src="/bfp_v1.json" path="/products" method="get" expanded="true" %} 
[bfp_v1.json](/bfp_v1.json) 
{% endswagger %}
```



