### PR TITLE
Docs to complement the async service request to FuPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _book
 *.epub
 *.mobi
 *.pdf
+.idea

--- a/overview/order-fulfillment.md
+++ b/overview/order-fulfillment.md
@@ -43,7 +43,7 @@ sequenceDiagram
 2. Once detected, the fulfiller reads the metadata, and processes the async payment off chain to the relevant FuP
 3. Store the transaction details from the FuP. We need to wait for a notification from the FuP.
 4. In T+1 the FuP sends a notification to the Fulfiller with the transaction details.
-5. The Fulfiller needs to verify the transaction details with the FuP to ensure about the transaction details.
+5. The Fulfiller needs to verify the transaction details with the FuP to ensure about transaction state.
 6. Once the FuP has responded, the fulfiller MUST submit a Fulfillment Result to the on-chain protocol. This is done submitting a result via the Bando Manager contract. 
 7. Once the result submission is stored in the contract. The user can now see the submission metadata.
 
@@ -65,7 +65,7 @@ sequenceDiagram
     FuP->>Fulfiller: Response for the async service
     Fulfiller->>Fulfiller: Wait for notification
     FuP->>Fulfiller: Notifies the status change for the async transaction
-    Fulfiller->>FuP: Process transaction details
+    Fulfiller->>FuP: Request transaction details
     FuP->>Fulfiller: Provides transaction details
     Fulfiller->>Manager: Submit Fulfillment Result
     Manager->>Manager: Store result

--- a/overview/order-fulfillment.md
+++ b/overview/order-fulfillment.md
@@ -61,11 +61,13 @@ sequenceDiagram
     Fulfiller->>Router: Listen to ServiceRequested event
     Fulfiller->>Fulfiller: Detect pending request
     Fulfiller->>Fulfiller: Read metadata
-    Fulfiller-)FuP: Process payment off-chain
-    FuP--)Fulfiller: Response for the async service
-    Fulfiller->>Manager: Submit Fulfillment Result
+    Fulfiller->>FuP: Process async payment off-chain
+    FuP->>Fulfiller: Response for the async service
+    Fulfiller->>Fulfiller: Wait for notification
     FuP->>Fulfiller: Notifies the status change for the async transaction
     Fulfiller->>FuP: Process transaction details
+    FuP->>Fulfiller: Provides transaction details
+    Fulfiller->>Manager: Submit Fulfillment Result
     Manager->>Manager: Store result
     Note over Manager: User can now see submission metadata
 ```

--- a/overview/order-fulfillment.md
+++ b/overview/order-fulfillment.md
@@ -7,6 +7,10 @@ description: >-
 
 Right after the funds have been transferred to the Bando Escrow contract, the request SHOULD now be considered as fulfillable. This means that a fulfiller can detect this pending service request and perform the necessary payment or order. 
 
+> **_NOTE:_**  The fulfillment can be performed in two different ways, Synchronous and asynchronous. For async services types, the fulfillment can take longer, because we need to wait for a notification of the service state from the provider.
+
+## Fulfillment of Sync Services
+
 1. To do this, the fulfiller can listen to the ServiceRequested event emitted by the Router after transfer and then process the request.
 2. Once detected, the fulfiller reads the metadata, and processes the payment off chain to the relevant FuP
 3. Once the FuP has responded, the fulfiller MUST submit a Fulfillment Result to the on-chain protocol. This is done submitting a result via the Bando Manager contract.
@@ -29,6 +33,39 @@ sequenceDiagram
     Fulfiller->>FuP: Process payment off-chain
     FuP-->>Fulfiller: Response
     Fulfiller->>Manager: Submit Fulfillment Result
+    Manager->>Manager: Store result
+    Note over Manager: User can now see submission metadata
+```
+
+## Fulfillment of Async Services
+
+1. To do this, the fulfiller can listen to the ServiceRequested event emitted by the Router after transfer and then process the request.
+2. Once detected, the fulfiller reads the metadata, and processes the async payment off chain to the relevant FuP
+3. Store the transaction details from the FuP. We need to wait for a notification from the FuP.
+4. In T+1 the FuP sends a notification to the Fulfiller with the transaction details.
+5. The Fulfiller needs to verify the transaction details with the FuP to ensure about the transaction details.
+6. Once the FuP has responded, the fulfiller MUST submit a Fulfillment Result to the on-chain protocol. This is done submitting a result via the Bando Manager contract. 
+7. Once the result submission is stored in the contract. The user can now see the submission metadata.
+
+```mermaid
+sequenceDiagram
+		box cyan smart contracts
+		    participant Router as BandoRouter
+		    participant Escrow as BandoEscrow
+		    participant Manager as BandoManagerContract
+		end
+    participant Fulfiller
+    participant FuP as Fulfillment Provider
+
+    Router->>Router: Emit ServiceRequested event
+    Fulfiller->>Router: Listen to ServiceRequested event
+    Fulfiller->>Fulfiller: Detect pending request
+    Fulfiller->>Fulfiller: Read metadata
+    Fulfiller-)FuP: Process payment off-chain
+    FuP--)Fulfiller: Response for the async service
+    Fulfiller->>Manager: Submit Fulfillment Result
+    FuP->>Fulfiller: Notifies the status change for the async transaction
+    Fulfiller->>FuP: Process transaction details
     Manager->>Manager: Store result
     Note over Manager: User can now see submission metadata
 ```


### PR DESCRIPTION
# Pull Request Overview

For some service types, the service request to FuPs can be fulfilled in an async way; this PR documents such use cases.

## Key Changes

1. Add the docs and diagrams


## Notes

```mermaid
sequenceDiagram
		box cyan smart contracts
		    participant Router as BandoRouter
		    participant Escrow as BandoEscrow
		    participant Manager as BandoManagerContract
		end
    participant Fulfiller
    participant FuP as Fulfillment Provider

    Router->>Router: Emit ServiceRequested event
    Fulfiller->>Router: Listen to ServiceRequested event
    Fulfiller->>Fulfiller: Detect pending request
    Fulfiller->>Fulfiller: Read metadata
    Fulfiller->>FuP: Process async payment off-chain
    FuP->>Fulfiller: Response for the async service
    Fulfiller->>Fulfiller: Wait for notification
    FuP->>Fulfiller: Notifies the status change for the async transaction
    Fulfiller->>FuP: Request transaction details
    FuP->>Fulfiller: Provides transaction details
    Fulfiller->>Manager: Submit Fulfillment Result
    Manager->>Manager: Store result
    Note over Manager: User can now see submission metadata
```