### PR TITLE
add video to quick start page

### DIFF
--- a/widget/quick-start.md
+++ b/widget/quick-start.md
@@ -17,6 +17,8 @@ The **Bando Widget** is a collection of prebuilt UI components designed to simpl
 - Compatibility with multiple frontend frameworks:
   - **React**, **Next.js**, **Vue**, **Nuxt.js**, **Svelte**, **Remix**, **Gatsby**, **Vite**, **CRA**, **RainbowKit**.
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/QKA4T3PUIps?si=o_KTUcKipf8-gT32" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ---
 
 ## Installation
@@ -65,7 +67,7 @@ Once the widget is installed, you can integrate it into your application with th
 
 ### 1. Import and Configure the Widget
 
-Create a configuration object to customize the widget’s appearance and behavior:
+Create a configuration object to customize the widget's appearance and behavior:
 
 ```tsx
 import { BandoWidget, WidgetConfig } from '@bandohq/widget';


### PR DESCRIPTION
# Pull Request Overview
add quick start video on a youtube iframe





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an embedded YouTube video to the Overview section of the Bando Widget documentation.
  - Corrected an apostrophe in the Getting Started section for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->