### PR TITLE
update wallet integrations page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -23,6 +23,7 @@
 * [Localization](widget/localization.md)
 * [Wallet Management](widget/wallet-management.md)
 * [Framework Integration](widget/framework-integration/README.md)
+* [Third Party Wallets Integration](widget/wallets-integration.md)
   * [Next.js](widget/framework-integration/nextjs.md)
   * [Svelte](widget/framework-integration/svelte.md)
 

--- a/widget/wallets-integration.md
+++ b/widget/wallets-integration.md
@@ -1,0 +1,42 @@
+---
+description: Learn how to integrate the Bando Widget inside wallet mini-apps (Farcaster, Binance, MiniPay, World App, and more).
+---
+
+# Third Party Wallet Integrations
+
+Build once. Run anywhere.  
+The **Bando Widget** is designed to work seamlessly inside wallet environments — even when your dApp runs as a mini-app.
+
+By default, the widget is ready to run inside:
+
+- **Farcaster**
+- **Binance**
+- **Opera MiniPay**
+
+If you want to integrate it inside **World App**, you’ll just need one extra setup step.
+
+---
+
+## World App Integration
+
+To use the Bando Widget inside **World App**, you must first install and configure the **World MiniKit**:
+
+- [Install World MiniKit](https://docs.world.org/mini-apps/quick-start/installing)
+- [Authenticate the user wallet](https://docs.world.org/mini-apps/commands/wallet-auth#using-the-command)
+
+Once installed, simply pass the `MiniKit` object as a **transaction provider** to the Bando Widget.
+
+### Example
+
+```typescript
+import { MiniKit } from "@worldcoin/minikit-js";
+
+export const Widget = () => {
+  const config = {
+    buildUrl: true,
+    transactionProvider: MiniKit,
+  } as Partial<WidgetConfig>;
+
+  return <BandoWidget integrator={integrator} config={config} />;
+};
+```


### PR DESCRIPTION
# Pull Request Overview
Guide to integrate the widget on Dapps that will be used inside third party wallets as mini apps



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “Third Party Wallets Integration” guide under the Spending Widget, detailing integration of the Bando Widget into wallet mini-apps.
  * Documented ready integrations (Farcaster, Binance, Opera MiniPay) and World App via World MiniKit, including installation, authentication, and configuring the widget with a transaction provider.
  * Included a TypeScript example showing configuration with MiniKit.
  * Updated the table of contents to include the new guide, positioned after “Framework Integration.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->